### PR TITLE
#10 Safely bind topic with fast retrys and fallback interval.

### DIFF
--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
@@ -25,7 +25,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
             private readonly TopicClient _topicClient;
             private readonly ILogger<AzureTopicPublisher> _logger;
             private readonly AzureBusTopicSettings _settings;
-
+            
             internal Binding(
                 AzureBusTopicSettings settings,
                 AzureBusTopicManagement queueManagement,
@@ -92,10 +92,8 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
             var topic = _settings.TopicNameBuilder(message.GetType());
 
             if (!_bindings.ContainsKey(topic))
-            {
                 return TryCreateBinding(topic, typeof(T), message, 5, 60);
-            }
-
+            
             return _bindings[topic].SendAsync(message);
         }
 

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
@@ -35,13 +35,9 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
             {
                 _logger = logger;
                 _settings = settings;
-
                 queueManagement.CreateTopicIfMissing(topic, type);
-
                 _topicClient = new TopicClient(settings.ConnectionString, topic);
-
                 _logger.LogInformation($"Created new MQ binding '{topic}'.");
-
             }
 
             public Task SendAsync(object message)
@@ -62,7 +58,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                 {
                     ContentType = "application/json"
                 };
-                
+
                 _settings.AzureMessagePropertyBuilder(message)
                     .ToList()
                     .ForEach(body.UserProperties.Add);
@@ -114,7 +110,6 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
         private Task TryCreateBinding(string topic, Type type, object message, int instantRecoveryTries, int lifeCycleRecoveryInterval)
         {
             CancellationTokenSource cancellation = new CancellationTokenSource();
-            Binding binding;
             int lifeCycleTryCount = 0;
 
             for (var i = 1; i <= instantRecoveryTries; i++)
@@ -122,7 +117,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                 _logger.LogInformation(
                     $"TryCreateBinding: Try {i} of {instantRecoveryTries} for binding ('{topic}')");
 
-                binding = TryBinding(topic, type, message);
+                var binding = TryBinding(topic, type, message);
                 if (binding != null)
                 {
                     _logger.LogInformation(
@@ -145,7 +140,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                 lifeCycleTryCount++;
                 _logger.LogInformation(
                     $"TryCreateBinding: Try {lifeCycleTryCount} of lifeCycleRecoveryInterval ('{topic}')");
-                binding = TryBinding(topic, type, message);
+                var binding = TryBinding(topic, type, message);
                 if (binding != null)
                 {
                     _logger.LogInformation(

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
@@ -93,7 +93,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
 
             if (!_bindings.ContainsKey(topic))
             {
-                return TryCreateBinding(topic, typeof(T), message, 5, 10); // TODO 60
+                return TryCreateBinding(topic, typeof(T), message, 5, 60);
             }
 
             return _bindings[topic].SendAsync(message);

--- a/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicPublisher.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicPublisher.cs
@@ -100,7 +100,6 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
             _logMessage = logMessage;
             _logError = logError;
             _factory = MessagingFactory.CreateFromConnectionString(settings.ConnectionString);
-
             _namespaceManager =
                 NamespaceManager.CreateFromConnectionString(settings.ConnectionString);
         }
@@ -136,7 +135,6 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
                 var binding = TryBinding(topic, type, message);
                 if (binding != null)
                 {
-                    
                     _logMessage($"TryCreateBinding: Binding successful ('{topic}', binding {i} of {instantRecoveryTries})");
                     _bindings.Add(topic, binding);
                     return ((Binding<T>) _bindings[queueName]).SendAsync(message, queueName);
@@ -174,8 +172,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
                     _namespaceManager.CreateTopic(_settings.TopicBuilderConfig(queueDescription, type));
                 }
                 var queueName = _settings.TopicNameBuilder(message.GetType());
-                return new Binding<T>(_factory, _namespaceManager, _settings, queueName
-                    , _logMessage, _logError);
+                return new Binding<T>(_factory, _namespaceManager, _settings, queueName, _logMessage, _logError);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## What
Safer way to bind Topic. If exception(s) happen when binding, this change will keep trying the bind as long as it will succeed. First it makes few fast tries, and after that it will fallback to interval of 60 sec to try again and again. Once binding is done, it will pass the original message to the publisher.

## To consider
I would suggest that we further generalize this so that other classes could also use this safe-binding. It would require to move the `Task TryCreateBinding` to its own class. 

## Legacy
Similar behavior is implemented in the Legacy part of the RxMq in `AzureBusTopicPublisher`. As there is a possibility to generalize this, I have not added any changes to that part, but it is due to be done (we want to make sure that project where legacy -part is being used is also covered).

## How to test
I would suggest to add some logic for throwing X amount of exceptions in the `AzureTopicPublisher` `internal Binding()` and running `dotnet test`.

Closes #10 