### PR TITLE
Added resubscription to subscription error handling

### DIFF
--- a/Protacon.RxMq.AzureServiceBus/Protacon.RxMq.AzureServiceBus.csproj
+++ b/Protacon.RxMq.AzureServiceBus/Protacon.RxMq.AzureServiceBus.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.ServiceBus.Fluent" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ServiceBus.Fluent" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicManagement.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicManagement.cs
@@ -47,7 +47,5 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                 _settings.AzureTopicBuilder(@namespace.Topics.Define(topicName), messageType);
             }
         }
-
-
     }
 }

--- a/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.1" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now topic subscription error handling makes sure topic and subscription exists. This handles case where topic or subscription is suddenly deleted.

For now, this is done only in when `ServiceBusCommunicationException` (missing subscription) or `MessagingEntityNotFoundException` (missing topic) is thrown.