### PR TITLE
add MessageCommunicationException for erroractions

### DIFF
--- a/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicSubscriber.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicSubscriber.cs
@@ -98,7 +98,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
             private void OptionsOnExceptionReceived(object sender, ExceptionReceivedEventArgs exceptionEventArgs)
             {
                 _logError($"Action '{exceptionEventArgs.Action}' caused exception {exceptionEventArgs.Exception}.");
-                if (exceptionEventArgs.Exception is MessagingEntityNotFoundException)
+                if (exceptionEventArgs.Exception is MessagingEntityNotFoundException || exceptionEventArgs.Exception is MessagingCommunicationException)
                 {
                     _errorActions.Add(this);
                 }


### PR DESCRIPTION
Legacy servicebus subscriber missed exceptions related to subscription missing . Thats why it did not recreate subscriptions when they were deleted for example in Azure



closes  https://github.com/protacon/Protacon.RxMq/issues/14