### PR TITLE
Feature/send async thread safe

### DIFF
--- a/Protacon.RxMq.AzureServiceBus.Tests/AzureBusTopicIntegrationTests.cs
+++ b/Protacon.RxMq.AzureServiceBus.Tests/AzureBusTopicIntegrationTests.cs
@@ -35,6 +35,9 @@ namespace Protacon.RxMq.AzureServiceBus.Tests
                 .FirstAsync();
         }
 
+
+        // testi joka heittää poikkeuksen ja kutsuu uudestaan send async
+
         [Fact]
         public async void WhenFiltersAreSet_ThenDontReturnInvalidTenantMessages()
         {

--- a/Protacon.RxMq.AzureServiceBus.Tests/AzureBusTopicIntegrationTests.cs
+++ b/Protacon.RxMq.AzureServiceBus.Tests/AzureBusTopicIntegrationTests.cs
@@ -36,45 +36,6 @@ namespace Protacon.RxMq.AzureServiceBus.Tests
         }
 
         [Fact]
-        public async void WhenMessageFails_ItsBeingSendAgain()
-        {
-            var settings = TestSettings.TopicSettingsOptions();
-            var subscriber = new AzureTopicSubscriber(settings, new AzureBusTopicManagement(settings), Substitute.For<ILogger<AzureTopicSubscriber>>());
-            var publisher = new AzureTopicPublisher(settings, new AzureBusTopicManagement(settings), Substitute.For<ILogger<AzureTopicPublisher>>());
-            int i = 0;
-            publisher
-            .When(x => {
-                i++;
-                x.SendAsync<TestMessageForTopic>(Arg.Any<TestMessageForTopic>());
-
-            })
-
-            .Do(x => {
-                if (i < 2) {
-            throw new Exception();
-            }
-                  });
-
-            var id = Guid.NewGuid();
-            var listener = subscriber.Messages<TestMessageForTopic>();
-
-            await publisher.SendAsync(new TestMessageForTopic
-            {
-                ExampleId = id
-            });
-
-            await listener
-                .Where(x => x.ExampleId == id)
-                .Timeout(TimeSpan.FromSeconds(10))
-                .FirstAsync(); 
-
-            publisher.SendAsync(Arg.Any<TestMessageForTopic>()).Should().Received(3);
-        }
-
-
-        // testi joka heittää poikkeuksen ja kutsuu uudestaan send async
-
-        [Fact]
         public async void WhenFiltersAreSet_ThenDontReturnInvalidTenantMessages()
         {
             // Arrrange.

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Azure.ServiceBus;
 using Protacon.RxMq.Abstractions.DefaultMessageRouting;

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicPublisher.cs
@@ -97,8 +97,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
         }
 
         public Task SendAsync<T>(T message) where T : new()
-        {
-            
+        { 
             try
             {
               var topic = _settings.TopicNameBuilder(message.GetType());
@@ -112,11 +111,14 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
             {
                  _logger.LogError($"{nameof(SendAsync)}: Failed to send async message '{message}' '{e.Message}' '{e.StackTrace}'");
                  if (RetrySendMsgCount < 3) {
+                     RetrySendMsgCount++;
                     _logger.LogInformation($"{nameof(SendAsync)}: trying to send message again, for {RetrySendMsgCount}. time");
-                    RetrySendMsgCount++;
-                    return SendAsync(message);
+                     return SendAsync(message);
+                 } 
+                 else
+                 {
+                     throw e;
                  }
-                 throw e;
             }
         }
 


### PR DESCRIPTION
SendAsynciä thread safeksi. Vanha toteutus käytti Dictionaryä jonne bindataan Topic subscription. Muutettu toteutus käyttämään ConcurrentDictionaryä. Lisäksi muutettu SendAsync  try-catch piiriin jottei se nosta poikkeusta ylös. 
