### PR TITLE
Feature/entity already exists support legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ Setting up test environment
     1. Create a copy of `developer-settings.example.json` with name `developer-settings.json`
     1. Replace `developer-settings.json` content with correct values
 1. Create testing environment
-    1. Run `Testing/Prepare-Environment.ps1` (see script for detailed
+    1. Replace "ResourceGroupHere" with the actual name of the RG
+    1. Run `Testing/Prepare-Environment.ps1 -EnvironmentName "ResourceGroupHere"` (see script for detailed
     documentation)
 1. Create client secrets
-    1. Run `Create-CrientSecrets.ps1`
+    1. 1. Replace "ResourceGroupHere" with the actual name of the RG
+    1. Run `Create-ClientSecrets.ps1 -EnvironmentName "ResourceGroupHere"`
 
 After running these steps, you should have a Service Bus in Azure and
 `client-secrets.json` -file for testing. Environment variables can also be used


### PR DESCRIPTION
Add support for Topic subscription for Legacy project to manage existing entities
- When active subscriber is changes e.g. on network failure, support internally the subscriber change and manage possible exsisting subscrioption from the previous client having these network or other problems
- One scenario could be two subscribers where A is active and B passive. A has network or server failure, and traffic is moved to B. B is now active and A passive. B will subscribe to same messages as A was. This can cause EntityAlreadyExsists -type exceptions on certain cases. Handle these internally.
- Now client can optionally implement Delete Subscription -logic when creating message subscriber - but is no longer necessary