### PR TITLE
Add .Net Framework versions to 4.7.2, 4.8 to Legacy and update deps

### DIFF
--- a/Create-ClientSecrets.ps1
+++ b/Create-ClientSecrets.ps1
@@ -1,24 +1,25 @@
 param(
-    [Parameter()][string]$SettingsFile = 'developer-settings.json'
+    [Parameter()][string]$SettingsFile = 'developer-settings.json',
+    [Parameter()][string]$EnvironmentName = $SettingsFile.ResourceGroupName
 )
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-Write-Host "Reading settings from file '$SettingsFile'"
+Write-Host "Reading settings from file $SettingsFile"
 $settingsJson = Get-Content -Raw -Path $SettingsFile | ConvertFrom-Json
 
 $context = Get-AzContext
 
-$busKey = Get-AzServiceBusKey -ResourceGroupName $settingsJson.ResourceGroupName -Namespace $settingsJson.ResourceGroupName -Name 'RootManageSharedAccessKey'
+$busKey = Get-AzServiceBusKey -ResourceGroupName $EnvironmentName -Namespace $EnvironmentName -Name 'RootManageSharedAccessKey'
 
 $output = @{
     ConnectionString         = $busKey.PrimaryConnectionString
-    AzureResourceGroup       = $settingsJson.ResourceGroupName
+    AzureResourceGroup       = $EnvironmentName
     AzureSubscriptionId      = $context.Subscription.Id
     AzureSpAppId             = $settingsJson.ServicePrincipal.AppId
     AzureSpPassword          = $settingsJson.ServicePrincipal.Password
     AzureSpTenantId          = $context.Tenant.Id
-    AzureNamespace           = $settingsJson.ResourceGroupName
+    AzureNamespace           = $EnvironmentName
     AzureRetryMinimumBackoff = 5
     AzureRetryMaximumBackoff = 10
     AzureMaximumRetryCount   = 10

--- a/Create-ClientSecrets.ps1
+++ b/Create-ClientSecrets.ps1
@@ -1,29 +1,33 @@
 param(
-    [Parameter()][string]$SettingsFile = 'developer-settings.json',
-    [Parameter()][string]$EnvironmentName = $SettingsFile.ResourceGroupName
+    [Parameter()][string]$SettingsFile = 'developer-settings.json'
 )
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-Write-Host "Reading settings from file $SettingsFile"
+Write-Host "Reading settings from file '$SettingsFile'"
 $settingsJson = Get-Content -Raw -Path $SettingsFile | ConvertFrom-Json
 
 $context = Get-AzContext
 
-$busKey = Get-AzServiceBusKey -ResourceGroupName $EnvironmentName -Namespace $EnvironmentName -Name 'RootManageSharedAccessKey'
+$busKey = Get-AzServiceBusKey -ResourceGroupName $settingsJson.ResourceGroupName -Namespace $settingsJson.ResourceGroupName -Name 'RootManageSharedAccessKey'
 
 $output = @{
     ConnectionString         = $busKey.PrimaryConnectionString
-    AzureResourceGroup       = $EnvironmentName
+    AzureResourceGroup       = $settingsJson.ResourceGroupName
     AzureSubscriptionId      = $context.Subscription.Id
     AzureSpAppId             = $settingsJson.ServicePrincipal.AppId
     AzureSpPassword          = $settingsJson.ServicePrincipal.Password
     AzureSpTenantId          = $context.Tenant.Id
-    AzureNamespace           = $EnvironmentName
+    AzureNamespace           = $settingsJson.ResourceGroupName
     AzureRetryMinimumBackoff = 5
     AzureRetryMaximumBackoff = 10
     AzureMaximumRetryCount   = 10
 }
 
-$output | ConvertTo-Json -depth 100 | Out-File "Protacon.RxMq.AzureServiceBus.Tests\client-secrets.json"
-Copy-Item "Protacon.RxMq.AzureServiceBus.Tests\client-secrets.json" -Destination "Protacon.RxMq.AzureServiceBusLegacy.Tests"
+$filename = "client-secrets.json"
+$projectLocation = "Protacon.RxMq.AzureServiceBus.Tests"
+$legacyProjectLocation = "Protacon.RxMq.AzureServiceBusLegacy.Tests"
+$output | ConvertTo-Json -depth 100 | Out-File "$projectLocation\$filename"
+Copy-Item "$projectLocation\$filename" -Destination $legacyProjectLocation
+
+Write-Host "Write file '$filename' to '$projectLocation', '$legacyProjectLocation'"

--- a/Protacon.RxMq.Abstractions/Protacon.RxMq.Abstractions.csproj
+++ b/Protacon.RxMq.Abstractions/Protacon.RxMq.Abstractions.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net48;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Protacon.RxMq.Abstractions/Protacon.RxMq.Abstractions.csproj
+++ b/Protacon.RxMq.Abstractions/Protacon.RxMq.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net48;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net472;net48;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Protacon.RxMq.AzureServiceBus/Protacon.RxMq.AzureServiceBus.csproj
+++ b/Protacon.RxMq.AzureServiceBus/Protacon.RxMq.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protacon.RxMq.AzureServiceBusLegacy.Tests/AzureBusQueueIntegrationTests.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy.Tests/AzureBusQueueIntegrationTests.cs
@@ -49,7 +49,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Tests
             };
 
             publisher.Invoking(x => x.SendAsync(message).Wait())
-                .ShouldNotThrow<Exception>();
+                .Should().NotThrow<Exception>();
 
             await subscriber.Messages<TestMessageForQueue>()
                 .Timeout(TimeSpan.FromSeconds(30))

--- a/Protacon.RxMq.AzureServiceBusLegacy.Tests/AzureBusTopicIntegrationTests.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy.Tests/AzureBusTopicIntegrationTests.cs
@@ -76,7 +76,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Tests
                 .Where(x => x.ExampleId == invalidTenantMessageId)
                 .Timeout(TimeSpan.FromSeconds(15))
                 .Invoking(x => x.FirstAsync().Wait())
-                .Should().NotThrow<TimeoutException>();
+                .Should().Throw<TimeoutException>();
         }
 
         [Fact]

--- a/Protacon.RxMq.AzureServiceBusLegacy.Tests/AzureBusTopicIntegrationTests.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy.Tests/AzureBusTopicIntegrationTests.cs
@@ -76,7 +76,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Tests
                 .Where(x => x.ExampleId == invalidTenantMessageId)
                 .Timeout(TimeSpan.FromSeconds(15))
                 .Invoking(x => x.FirstAsync().Wait())
-                .ShouldThrow<TimeoutException>();
+                .Should().NotThrow<TimeoutException>();
         }
 
         [Fact]

--- a/Protacon.RxMq.AzureServiceBusLegacy.Tests/Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj
+++ b/Protacon.RxMq.AzureServiceBusLegacy.Tests/Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net48;</TargetFrameworks>
+    <TargetFrameworks>net452;net472;net48;</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Protacon.RxMq.AzureServiceBusLegacy.Tests/Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj
+++ b/Protacon.RxMq.AzureServiceBusLegacy.Tests/Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net472;net48;</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="FluentAssertions" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NSubstitute" Version="1.10.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
@@ -5,11 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
+
+  <Import Project="packagerefs.net472.targets" Condition="'$(TargetFramework)' == 'net472'" />
+  <Import Project="packagerefs.net48.targets" Condition="'$(TargetFramework)' == 'net48'" />
 
   <ItemGroup>
     <ProjectReference Include="..\Protacon.RxMq.Abstractions\Protacon.RxMq.Abstractions.csproj" />

--- a/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net48;</TargetFrameworks>
+    <TargetFrameworks>net452;net472;net48;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
+  <Import Project="packagerefs.net452.targets" Condition="'$(TargetFramework)' == 'net452'" />
   <Import Project="packagerefs.net472.targets" Condition="'$(TargetFramework)' == 'net472'" />
   <Import Project="packagerefs.net48.targets" Condition="'$(TargetFramework)' == 'net48'" />
 

--- a/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Protacon.RxMq.AzureServiceBusLegacy.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net472;net48;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Protacon.RxMq.AzureServiceBusLegacy/packagerefs.net452.targets
+++ b/Protacon.RxMq.AzureServiceBusLegacy/packagerefs.net452.targets
@@ -1,0 +1,6 @@
+﻿<Project>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+  </ItemGroup>
+</Project>

--- a/Protacon.RxMq.AzureServiceBusLegacy/packagerefs.net472.targets
+++ b/Protacon.RxMq.AzureServiceBusLegacy/packagerefs.net472.targets
@@ -1,0 +1,6 @@
+﻿<Project>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+  </ItemGroup>
+</Project>

--- a/Protacon.RxMq.AzureServiceBusLegacy/packagerefs.net48.targets
+++ b/Protacon.RxMq.AzureServiceBusLegacy/packagerefs.net48.targets
@@ -1,0 +1,6 @@
+﻿<Project>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ subscriber.Messages<TestMessage>().Subscribe(message => Console.WriteLine(x.Exam
 
 Abstraction over Azure Service Bus.
 
-Contains modern .NET Core version and legacy (pre 4.7.2) version with full framework.
+Contains modern .NET Core version and legacy (4.7.2, 4.8) version with full framework.
 
 ## Configuring
 
@@ -52,7 +52,7 @@ Configure `AzureQueueMqSettings`, there are configuration methods which can be o
 
 ## Developing
 
-Requires NET core 2.x. and .NET Framework SDK 4.5.2 and 4.6.1
+Requires NET core 2.x. and .NET Framework SDK 4.7.2 and 4.8
 
 Setting up test environment
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ subscriber.Messages<TestMessage>().Subscribe(message => Console.WriteLine(x.Exam
 
 Abstraction over Azure Service Bus.
 
-Contains modern .NET Core version and legacy (4.7.2, 4.8) version with full framework.
+Contains modern .NET Core version and legacy (4.5.2, 4.7.2, 4.8) version with full framework.
 
 ## Configuring
 
@@ -52,7 +52,7 @@ Configure `AzureQueueMqSettings`, there are configuration methods which can be o
 
 ## Developing
 
-Requires NET core 2.x. and .NET Framework SDK 4.7.2 and 4.8
+Requires NET core 2.x. and .NET Framework SDK 4.5.2, 4.7.2 and 4.8
 
 Setting up test environment
 


### PR DESCRIPTION
Add .Net Framework versions to 4.7.2, 4.8 and update deps
- Drop net461 support from non-Legacy
- Add net48 support for non-Legacy
- Add net472 and net48 support for Legacy
- Add net472 to net48 for non-Legacy
- Update deps based on targeting framework. When applicant, updates:
  - Newtonsoft.Json 10.0.3 -> 13.0.1
  - System.Reactive 3.1.1 -> 5.0.0
- Shared dep updates as following:
  - FluentAssertions 4.19.4 -> 5.1.2
  - Microsoft.NET.Test.Sdk 15.3.0-preview -> 15.6.0
  - Microsoft.NETFramework.ReferenceAssemblies 1.0.0 -> 1.0.2

This will drop net461 support, and we will publish RxMq version 2.0.0 from this as this is a breaking change.