### PR TITLE
Fix obsolete warnings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Protacon.RxMq.ConsoleExample/bin/Debug/net5.0/Protacon.RxMq.ConsoleExample.dll",
+            "program": "${workspaceFolder}/Protacon.RxMq.ConsoleExample/bin/Debug/netcoreapp3.1</Protacon.RxMq.ConsoleExample.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Protacon.RxMq.ConsoleExample/",
             "console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,22 +1,22 @@
 {
-   // Use IntelliSense to find out which attributes exist for C# debugging
-   // Use hover for the description of the existing attributes
-   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-   "version": "0.2.0",
-   "configurations": [
+    // Use IntelliSense to find out which attributes exist for C# debugging
+    // Use hover for the description of the existing attributes
+    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+    "version": "0.2.0",
+    "configurations": [
         {
             "name": ".NET Core Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Protacon.RxMq.AzureServiceBus.Tests/bin/Debug/netcoreapp2.0/Protacon.RxMq.AzureServiceBus.Tests.dll",
+            "program": "${workspaceFolder}/Protacon.RxMq.ConsoleExample/bin/Debug/net5.0/Protacon.RxMq.ConsoleExample.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/Protacon.RxMq.AzureServiceBus.Tests",
-            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "cwd": "${workspaceFolder}/Protacon.RxMq.ConsoleExample/",
             "console": "internalConsole",
             "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart"
+            "internalConsoleOptions": "openOnSessionStart",
+            "requireExactSource": false
         },
         {
             "name": ".NET Core Attach",

--- a/Protacon.RxMq.AzureServiceBus.Tests/Protacon.RxMq.AzureServiceBus.Tests.csproj
+++ b/Protacon.RxMq.AzureServiceBus.Tests/Protacon.RxMq.AzureServiceBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Protacon.RxMq.AzureServiceBus.Tests/Protacon.RxMq.AzureServiceBus.Tests.csproj
+++ b/Protacon.RxMq.AzureServiceBus.Tests/Protacon.RxMq.AzureServiceBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Protacon.RxMq.AzureServiceBus/Protacon.RxMq.AzureServiceBus.csproj
+++ b/Protacon.RxMq.AzureServiceBus/Protacon.RxMq.AzureServiceBus.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net48;</TargetFrameworks>
+    <!-- Disable warnings in RegisterMessageHandler etc. -->
+    <NoWarn>$(NoWarn);1998</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus.Fluent" Version="1.18.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />

--- a/Protacon.RxMq.ConsoleExample/Protacon.RxMq.ConsoleExample.csproj
+++ b/Protacon.RxMq.ConsoleExample/Protacon.RxMq.ConsoleExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Protacon.RxMq.ConsoleExample/Protacon.RxMq.ConsoleExample.csproj
+++ b/Protacon.RxMq.ConsoleExample/Protacon.RxMq.ConsoleExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
 
 - job: 'publish'
   dependsOn: 'build'
-  condition: eq(variables.isTagBuild, true)
+  condition: and(succeeded(), eq(variables.isTagBuild, true))
   steps:
   - pwsh: |
         $tag = ($Env:BUILD_SOURCEBRANCH -Replace 'refs/tags/','')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
     - "*"
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2022'
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
* Update to netcoreapp3.1 for test projects
  * NOTE: Updating to net5.0 would require updating `Microsoft.Azure.ServiceBus`. 
* Update azure-pipelines to `windows-2022` because old image is going to be removed in next month. See https://github.com/actions/virtual-environments/issues/4312 for more information.