### PR TITLE
Implement IHasCorrelationId for Legacy project

### DIFF
--- a/Protacon.RxMq.AzureServiceBusLegacy.Tests/Messages/TestMessageForTopic.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy.Tests/Messages/TestMessageForTopic.cs
@@ -3,9 +3,10 @@ using Protacon.RxMq.Abstractions.DefaultMessageRouting;
 
 namespace Protacon.RxMq.AzureServiceBusLegacy.Tests.Messages
 {
-    public class TestMessageForTopic : ITopicItem
+    public class TestMessageForTopic : ITopicItem, IHasCorrelationId
     {
         public Guid ExampleId { get; set; }
+        public string CorrelationId { get; set; }
         public Guid TenantId { get; set; }
         public string TopicName => "testmessages_topic";
     }

--- a/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicPublisher.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicPublisher.cs
@@ -10,6 +10,7 @@ using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Protacon.RxMq.Abstractions;
+using Protacon.RxMq.Abstractions.DefaultMessageRouting;
 
 namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
 {
@@ -59,7 +60,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
 
                 var body =
                     JsonConvert.SerializeObject(
-                        new {Data = message},
+                        new { Data = message },
                         Formatting.None,
                         new JsonSerializerSettings
                         {
@@ -74,6 +75,11 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
                 {
                     ContentType = "application/json"
                 };
+
+                if (message is IHasCorrelationId correlationMessage)
+                {
+                    brokeredMessage.CorrelationId = correlationMessage.CorrelationId ?? brokeredMessage.CorrelationId;
+                }
 
                 _azureTopicMqSettings.AzureMessagePropertyBuilder(message)
                     .ToList()

--- a/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicSubscriber.cs
+++ b/Protacon.RxMq.AzureServiceBusLegacy/Topic/AzureBusTopicSubscriber.cs
@@ -49,11 +49,7 @@ namespace Protacon.RxMq.AzureServiceBusLegacy.Topic
                 MakeSureSubscriptionExists(namespaceManager, settings, topicPath, subscriptionName, true);
 
                 _receiver = messagingFactory.CreateSubscriptionClient(topicPath, subscriptionName);
-                _receiver.RemoveRule("$default");
-
-                settings.AzureSubscriptionRules
-                    .ToList()
-                    .ForEach(x => _receiver.AddRule(x.Key, x.Value));
+                UpdateRules(settings);
 
                 _options = new OnMessageOptions { AutoComplete = true };
                 _options.ExceptionReceived += OptionsOnExceptionReceived;

--- a/Protacon.RxMq.LegacyConsoleExample/App.config
+++ b/Protacon.RxMq.LegacyConsoleExample/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/Protacon.RxMq.LegacyConsoleExample/LegacyMessageService.cs
+++ b/Protacon.RxMq.LegacyConsoleExample/LegacyMessageService.cs
@@ -33,7 +33,7 @@ namespace Protacon.RxMq.LegacyConsoleExample
 
         private void HandleFirstCorrelation(CorrelationLegacyTestMessage1 message)
         {
-            Console.WriteLine("Received legacy correlation message 1. Correlatio ID " + message.CorrelationId);
+            Console.WriteLine("Received legacy correlation message 1. Correlation ID " + message.CorrelationId);
             _publisher.SendAsync(new CorrelationLegacyTestMessage2
             {
                 CorrelationId = message.CorrelationId
@@ -42,7 +42,7 @@ namespace Protacon.RxMq.LegacyConsoleExample
 
         private void HandleSecondCorrelation(CorrelationLegacyTestMessage2 message)
         {
-            Console.WriteLine("Received legacy correlation message 2. Correlatio ID " + message.CorrelationId);
+            Console.WriteLine("Received legacy correlation message 2. Correlation ID " + message.CorrelationId);
             _publisher.SendAsync(new CorrelationLegacyTestMessage3
             {
                 CorrelationId = message.CorrelationId
@@ -51,7 +51,7 @@ namespace Protacon.RxMq.LegacyConsoleExample
 
         private void HandleThirdCorrelation(CorrelationLegacyTestMessage3 message)
         {
-            Console.WriteLine("Received legacy correlation message 3. Correlatio ID " + message.CorrelationId);
+            Console.WriteLine("Received legacy correlation message 3. Correlation ID " + message.CorrelationId);
             Console.WriteLine("This is last legacy message of correlation saga.");
         }
 
@@ -77,21 +77,18 @@ namespace Protacon.RxMq.LegacyConsoleExample
     public class CorrelationLegacyTestMessage1 : ITopicItem, IHasCorrelationId
     {
         public string TopicName => "correlation-legacy-test-message1";
-
         public string CorrelationId { get; set; }
     }
 
     public class CorrelationLegacyTestMessage2 : ITopicItem, IHasCorrelationId
     {
         public string TopicName => "correlation-legacy-test-message2";
-
         public string CorrelationId { get; set; }
     }
 
     public class CorrelationLegacyTestMessage3 : ITopicItem, IHasCorrelationId
     {
         public string TopicName => "correlation-legacy-test-message3";
-
         public string CorrelationId { get; set; }
     }
 }

--- a/Protacon.RxMq.LegacyConsoleExample/LegacyMessageService.cs
+++ b/Protacon.RxMq.LegacyConsoleExample/LegacyMessageService.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Threading;
+using Protacon.RxMq.Abstractions;
+using Protacon.RxMq.Abstractions.DefaultMessageRouting;
+using Protacon.RxMq.AzureServiceBusLegacy.Tests;
+using Protacon.RxMq.AzureServiceBusLegacy.Topic;
+
+namespace Protacon.RxMq.LegacyConsoleExample
+{
+    public class LegacyMessageService : IDisposable
+    {
+        private readonly IMqTopicPublisher _publisher;
+        private readonly IMqTopicSubscriber _subscriber;
+        private readonly Timer _timer;
+
+        public LegacyMessageService()
+        {
+            var settings = TestSettings.MqSettingsForTopic();
+            _publisher = new AzureBusTopicPublisher(settings, Console.WriteLine, Console.WriteLine);
+            _subscriber = new AzureBusTopicSubscriber(settings, Console.WriteLine, Console.WriteLine);
+
+            Console.WriteLine("Starting legacy message service");
+            var listener1 = _subscriber.Messages<CorrelationLegacyTestMessage1>();
+            var listener2 = _subscriber.Messages<CorrelationLegacyTestMessage2>();
+            var listener3 = _subscriber.Messages<CorrelationLegacyTestMessage3>();
+
+            listener1.Subscribe(HandleFirstCorrelation);
+            listener2.Subscribe(HandleSecondCorrelation);
+            listener3.Subscribe(HandleThirdCorrelation);
+
+            _timer = new Timer(Execute, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15));
+        }
+
+        private void HandleFirstCorrelation(CorrelationLegacyTestMessage1 message)
+        {
+            Console.WriteLine("Received legacy correlation message 1. Correlatio ID " + message.CorrelationId);
+            _publisher.SendAsync(new CorrelationLegacyTestMessage2
+            {
+                CorrelationId = message.CorrelationId
+            });
+        }
+
+        private void HandleSecondCorrelation(CorrelationLegacyTestMessage2 message)
+        {
+            Console.WriteLine("Received legacy correlation message 2. Correlatio ID " + message.CorrelationId);
+            _publisher.SendAsync(new CorrelationLegacyTestMessage3
+            {
+                CorrelationId = message.CorrelationId
+            });
+        }
+
+        private void HandleThirdCorrelation(CorrelationLegacyTestMessage3 message)
+        {
+            Console.WriteLine("Received legacy correlation message 3. Correlatio ID " + message.CorrelationId);
+            Console.WriteLine("This is last legacy message of correlation saga.");
+        }
+
+        private void Execute(object state)
+        {
+            var correlationId = Guid.NewGuid();
+            var correlationKey = $"COR-{correlationId}";
+            Console.WriteLine("Starting legacy correlation chain with " + correlationKey);
+            var testMessage = new CorrelationLegacyTestMessage1
+            {
+                CorrelationId = correlationKey
+            };
+            _publisher.SendAsync(testMessage);
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+            _subscriber.Dispose();
+        }
+    }
+
+    public class CorrelationLegacyTestMessage1 : ITopicItem, IHasCorrelationId
+    {
+        public string TopicName => "correlation-legacy-test-message1";
+
+        public string CorrelationId { get; set; }
+    }
+
+    public class CorrelationLegacyTestMessage2 : ITopicItem, IHasCorrelationId
+    {
+        public string TopicName => "correlation-legacy-test-message2";
+
+        public string CorrelationId { get; set; }
+    }
+
+    public class CorrelationLegacyTestMessage3 : ITopicItem, IHasCorrelationId
+    {
+        public string TopicName => "correlation-legacy-test-message3";
+
+        public string CorrelationId { get; set; }
+    }
+}

--- a/Protacon.RxMq.LegacyConsoleExample/Program.cs
+++ b/Protacon.RxMq.LegacyConsoleExample/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Protacon.RxMq.LegacyConsoleExample
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            new LegacyMessageService();
+
+            Console.WriteLine("Press any key to stop");
+            Console.ReadKey();
+        }
+    }
+}

--- a/Protacon.RxMq.LegacyConsoleExample/Properties/AssemblyInfo.cs
+++ b/Protacon.RxMq.LegacyConsoleExample/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Protacon.RxMq.LegacyConsoleExample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Protacon.RxMq.LegacyConsoleExample")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("77ffa43c-4d44-49d4-9b5f-3d0855ac36c3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Protacon.RxMq.LegacyConsoleExample/Protacon.RxMq.LegacyConsoleExample.csproj
+++ b/Protacon.RxMq.LegacyConsoleExample/Protacon.RxMq.LegacyConsoleExample.csproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Protacon.RxMq.LegacyConsoleExample</RootNamespace>
+    <AssemblyName>Protacon.RxMq.LegacyConsoleExample</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive, Version=5.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.5.0.0\lib\net472\System.Reactive.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LegacyMessageService.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Protacon.RxMq.Abstractions\Protacon.RxMq.Abstractions.csproj">
+      <Project>{f4019994-11de-4ce8-980e-1b2e2709e05e}</Project>
+      <Name>Protacon.RxMq.Abstractions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Protacon.RxMq.AzureServiceBusLegacy.Tests\Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj">
+      <Project>{6963fd29-24e1-4300-af88-98a43f536ab4}</Project>
+      <Name>Protacon.RxMq.AzureServiceBusLegacy.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Protacon.RxMq.AzureServiceBusLegacy\Protacon.RxMq.AzureServiceBusLegacy.csproj">
+      <Project>{4cc2b564-5b30-445e-94ac-2b74fdf20a06}</Project>
+      <Name>Protacon.RxMq.AzureServiceBusLegacy</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Protacon.RxMq.LegacyConsoleExample/packages.config
+++ b/Protacon.RxMq.LegacyConsoleExample/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+</packages>

--- a/Protacon.RxMq.sln
+++ b/Protacon.RxMq.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.RxMq.Abstractions", "Protacon.RxMq.Abstractions\Protacon.RxMq.Abstractions.csproj", "{F4019994-11DE-4CE8-980E-1B2E2709E05E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.RxMq.AzureServiceBus", "Protacon.RxMq.AzureServiceBus\Protacon.RxMq.AzureServiceBus.csproj", "{D64BB6F2-5613-45E9-B440-3E579E8F2008}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Protacon.RxMq.AzureServiceBus.Tests", "Protacon.RxMq.AzureServiceBus.Tests\Protacon.RxMq.AzureServiceBus.Tests.csproj", "{6A7DF81D-5B29-462B-BFC0-D67372D92C58}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.RxMq.AzureServiceBus.Tests", "Protacon.RxMq.AzureServiceBus.Tests\Protacon.RxMq.AzureServiceBus.Tests.csproj", "{6A7DF81D-5B29-462B-BFC0-D67372D92C58}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Protacon.RxMq.AzureServiceBusLegacy", "Protacon.RxMq.AzureServiceBusLegacy\Protacon.RxMq.AzureServiceBusLegacy.csproj", "{4CC2B564-5B30-445E-94AC-2B74FDF20A06}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.RxMq.AzureServiceBusLegacy", "Protacon.RxMq.AzureServiceBusLegacy\Protacon.RxMq.AzureServiceBusLegacy.csproj", "{4CC2B564-5B30-445E-94AC-2B74FDF20A06}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Protacon.RxMq.AzureServiceBusLegacy.Tests", "Protacon.RxMq.AzureServiceBusLegacy.Tests\Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj", "{6963FD29-24E1-4300-AF88-98A43F536AB4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.RxMq.AzureServiceBusLegacy.Tests", "Protacon.RxMq.AzureServiceBusLegacy.Tests\Protacon.RxMq.AzureServiceBusLegacy.Tests.csproj", "{6963FD29-24E1-4300-AF88-98A43F536AB4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Protacon.RxMq.ConsoleExample", "Protacon.RxMq.ConsoleExample\Protacon.RxMq.ConsoleExample.csproj", "{C8E590C3-F917-4EE7-AA2F-F22B43AEDBD2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.RxMq.ConsoleExample", "Protacon.RxMq.ConsoleExample\Protacon.RxMq.ConsoleExample.csproj", "{C8E590C3-F917-4EE7-AA2F-F22B43AEDBD2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Protacon.RxMq.LegacyConsoleExample", "Protacon.RxMq.LegacyConsoleExample\Protacon.RxMq.LegacyConsoleExample.csproj", "{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,6 +99,18 @@ Global
 		{C8E590C3-F917-4EE7-AA2F-F22B43AEDBD2}.Release|x64.Build.0 = Release|Any CPU
 		{C8E590C3-F917-4EE7-AA2F-F22B43AEDBD2}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8E590C3-F917-4EE7-AA2F-F22B43AEDBD2}.Release|x86.Build.0 = Release|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Debug|x86.Build.0 = Debug|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Release|x64.Build.0 = Release|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{77FFA43C-4D44-49D4-9B5F-3D0855AC36C3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Implement IHasCorrelationId for Legacy project
- Based on https://github.com/by-pinja/Protacon.RxMq/pull/32
- Add CorrelationId to brokered messages
- Add new integration test
- Add test console example application similar to what non-Legacy has

NOTE: Possibly less effective than non-Legacy lib implementation as this Legacy project does not use `ILogger` based logging. 