### PR TITLE
Feature/37 additional topic settings

### DIFF
--- a/Protacon.RxMq.Abstractions/DefaultMessageRouting/ITopicItem.cs
+++ b/Protacon.RxMq.Abstractions/DefaultMessageRouting/ITopicItem.cs
@@ -8,5 +8,6 @@
     public interface IConfigurableTopicItem : ITopicItem
     {
         int PrefetchCount { get; }
+        string ReceiveMode { get; }
     }
 }

--- a/Protacon.RxMq.Abstractions/DefaultMessageRouting/ITopicItem.cs
+++ b/Protacon.RxMq.Abstractions/DefaultMessageRouting/ITopicItem.cs
@@ -4,4 +4,9 @@
     {
         string TopicName { get; }
     }
+
+    public interface IConfigurableTopicItem : ITopicItem
+    {
+        int PrefetchCount { get; }
+    }
 }

--- a/Protacon.RxMq.AzureServiceBus/Queue/AzureBusSubscriber.cs
+++ b/Protacon.RxMq.AzureServiceBus/Queue/AzureBusSubscriber.cs
@@ -29,6 +29,8 @@ namespace Protacon.RxMq.AzureServiceBus.Queue
                 queueManagement.CreateQueIfMissing(queueName, typeof(T));
 
                 var queueClient = new QueueClient(settings.ConnectionString, queueName);
+                queueClient.PrefetchCount = settings.DefaultPrefetchCount;
+                
                 _excludeQueuesFromLogging = new LoggingConfiguration().ExcludeQueuesFromLogging();
 
                 queueClient.RegisterMessageHandler(

--- a/Protacon.RxMq.AzureServiceBus/Queue/AzureQueueMqSettings.cs
+++ b/Protacon.RxMq.AzureServiceBus/Queue/AzureQueueMqSettings.cs
@@ -5,6 +5,7 @@ namespace Protacon.RxMq.AzureServiceBus.Queue
 {
     public class AzureBusQueueSettings: AzureMqSettingsBase
     {
+        public int DefaultPrefetchCount { get; set; } = 0;
         public Func<Type, string> QueueNameBuilderForSubscriber { get; set; } = type =>
         {
             var instance = Activator.CreateInstance(type);

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
@@ -8,6 +8,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
     public class AzureBusTopicSettings : AzureMqSettingsBase
     {
         public string TopicSubscriberId { get; set; } = Environment.MachineName;
+        public int DefaultPrefetchCount { get; set; } = 0;
 
         public Func<Type, string> TopicNameBuilder { get; set; } = type =>
         {

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
@@ -9,6 +9,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
     {
         public string TopicSubscriberId { get; set; } = Environment.MachineName;
         public int DefaultPrefetchCount { get; set; } = 0;
+        public string DefaultReceiveMode { get; set; } = "PeekLock";
 
         public Func<Type, string> TopicNameBuilder { get; set; } = type =>
         {
@@ -22,18 +23,18 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
             throw new InvalidOperationException($"Default implementation of queue name builder expects used objects to extend '{nameof(ITopicItem)}'");
         };
 
-        public Func<Type, Tuple<string, int?>> TopicConfigBuilder { get; set; } = type =>
+        public Func<Type, Tuple<string, int?, string>> TopicConfigBuilder { get; set; } = type =>
         {
             var instance = Activator.CreateInstance(type);
 
             if (instance is IConfigurableTopicItem cti)
             {
-                return new Tuple<string, int?>(cti.TopicName, cti.PrefetchCount);
+                return new Tuple<string, int?, string>(cti.TopicName, cti.PrefetchCount, cti.ReceiveMode);
             }
 
             if (instance is ITopicItem t)
             {
-                return new Tuple<string, int?>(t.TopicName, null);
+                return new Tuple<string, int?, string>(t.TopicName, null, "");
             }
 
             throw new InvalidOperationException($"Default implementation of queue name builder expects used objects to extend '{nameof(ITopicItem)}' or '{nameof(IConfigurableTopicItem)}'");

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicMqSettings.cs
@@ -22,6 +22,23 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
             throw new InvalidOperationException($"Default implementation of queue name builder expects used objects to extend '{nameof(ITopicItem)}'");
         };
 
+        public Func<Type, Tuple<string, int?>> TopicConfigBuilder { get; set; } = type =>
+        {
+            var instance = Activator.CreateInstance(type);
+
+            if (instance is IConfigurableTopicItem cti)
+            {
+                return new Tuple<string, int?>(cti.TopicName, cti.PrefetchCount);
+            }
+
+            if (instance is ITopicItem t)
+            {
+                return new Tuple<string, int?>(t.TopicName, null);
+            }
+
+            throw new InvalidOperationException($"Default implementation of queue name builder expects used objects to extend '{nameof(ITopicItem)}' or '{nameof(IConfigurableTopicItem)}'");
+        };
+
         public Action<Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IBlank, Type> AzureTopicBuilder { get; set; } = (create, messageType) =>
         {
             create

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicSubscriber.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicSubscriber.cs
@@ -39,7 +39,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                 AzureBusTopicManagement topicManagement, BlockingCollection<IBinding> errorActions)
             {
                 _excludeTopicsFromLogging = new LoggingConfiguration().ExcludeTopicsFromLogging();
-                var topicName = settings.TopicNameBuilder(typeof(T));
+                var (topicName, prefetchCount) = settings.TopicConfigBuilder(typeof(T));
                 var subscriptionName = $"{topicName}.{settings.TopicSubscriberId}";
 
                 topicManagement.CreateSubscriptionIfMissing(topicName, subscriptionName, typeof(T));
@@ -49,7 +49,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                     ConnectionString = settings.ConnectionString,
                     TopicName = topicName,
                     SubscriptionName = subscriptionName,
-                    PrefetchCount = settings.DefaultPrefetchCount
+                    PrefetchCount = prefetchCount ?? settings.DefaultPrefetchCount
                 });
                 
                 UpdateRules(subscriptionClient, settings);
@@ -88,7 +88,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
 
             public void ReCreate(AzureBusTopicSettings settings, AzureBusTopicManagement topicManagement)
             {
-                var topicName = settings.TopicNameBuilder(typeof(T));
+                var (topicName, prefetchCount) = settings.TopicConfigBuilder(typeof(T));
                 var subscriptionName = $"{topicName}.{settings.TopicSubscriberId}";
 
                 topicManagement.CreateSubscriptionIfMissing(topicName, subscriptionName, typeof(T));
@@ -98,7 +98,7 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                     ConnectionString = settings.ConnectionString,
                     TopicName = topicName,
                     SubscriptionName = subscriptionName,
-                    PrefetchCount = settings.DefaultPrefetchCount
+                    PrefetchCount = prefetchCount ?? settings.DefaultPrefetchCount
                 });
                 
                 UpdateRules(subscriptionClient, settings);

--- a/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicSubscriber.cs
+++ b/Protacon.RxMq.AzureServiceBus/Topic/AzureTopicSubscriber.cs
@@ -82,6 +82,8 @@ namespace Protacon.RxMq.AzureServiceBus.Topic
                             errorActions.Add(this);
                         }
                     }));
+
+                logging.LogInformation("Created SubscriptionClient for {topicName} with prefetchCount {prefetchCount}", topicName, subscriptionClient.PrefetchCount);
             }
 
             public void ReCreate(AzureBusTopicSettings settings, AzureBusTopicManagement topicManagement)

--- a/Protacon.RxMq.ConsoleExample/appsettings.json
+++ b/Protacon.RxMq.ConsoleExample/appsettings.json
@@ -15,6 +15,7 @@
         "AzureSpAppId": "",
         "AzureSpPassword": "",
         "AzureNamespace": "",
-        "DefaultPrefetchCount": 0
+        "DefaultPrefetchCount": 0,
+        "DefaultReceiveMode": "PeekLock"
     }
 }

--- a/Protacon.RxMq.ConsoleExample/appsettings.json
+++ b/Protacon.RxMq.ConsoleExample/appsettings.json
@@ -14,6 +14,7 @@
         "ConnectionString": "",
         "AzureSpAppId": "",
         "AzureSpPassword": "",
-        "AzureNamespace": ""
+        "AzureNamespace": "",
+        "DefaultPrefetchCount": 0
     }
 }


### PR DESCRIPTION
PrefetchCount allows client to receive more messages from service bus topic in a single batch. This value defaults to 0 which means items are brought one by one. With PrefetchCount, more messages can be handled by client and messages do not clog the topic.

ReceiveMode changes the way ServiceBus handles messages. Default value PeekLock does not delete message from Service Bus until it receives confirmation from client that message has been received. ReceiveAndDelete allows ServiceBus to remove message from topic queue as soon as it is delivered regardless of client status.
