### PR TITLE
Remove legacy (4.5) references from docs, tools and pipelines

### DIFF
--- a/Create-ClientSecrets.ps1
+++ b/Create-ClientSecrets.ps1
@@ -27,8 +27,6 @@ $output = @{
 
 $filename = "client-secrets.json"
 $projectLocation = "Protacon.RxMq.AzureServiceBus.Tests"
-$legacyProjectLocation = "Protacon.RxMq.AzureServiceBusLegacy.Tests"
 $output | ConvertTo-Json -depth 100 | Out-File "$projectLocation\$filename"
-Copy-Item "$projectLocation\$filename" -Destination $legacyProjectLocation
 
-Write-Host "Write file '$filename' to '$projectLocation', '$legacyProjectLocation'"
+Write-Host "Write file '$filename' to '$projectLocation'"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://dev.azure.com/Protacon/Protacon.RxMq/_apis/build/status/by-pinja.Protacon.RxMq?branchName=refs%2Fpull%2F32%2Fmerge)](https://dev.azure.com/Protacon/Protacon.RxMq/_build/latest?definitionId=19&branchName=refs%2Fpull%2F32%2Fmerge)
 [![Nuget](https://img.shields.io/nuget/dt/Protacon.RxMq.Abstractions.svg)](https://www.nuget.org/packages/Protacon.RxMq.Abstractions/)
 [![Nuget](https://img.shields.io/nuget/dt/Protacon.RxMq.AzureServiceBus.svg)](https://www.nuget.org/packages/Protacon.RxMq.AzureServiceBus/)
-[![Nuget](https://img.shields.io/nuget/dt/Protacon.RxMq.AzureServiceBusLegacy.svg)](https://www.nuget.org/packages/Protacon.RxMq.AzureServiceBusLegacy/)
 
 # RxMq
 
@@ -41,7 +40,7 @@ subscriber.Messages<TestMessage>().Subscribe(message => Console.WriteLine(x.Exam
 
 Abstraction over Azure Service Bus.
 
-Contains modern .NET Core version and legacy (4.5.2, 4.7.2, 4.8) version with full framework.
+Contains modern .NET Core version and legacy (4.8) version with full framework.
 
 ## Configuring
 
@@ -52,7 +51,7 @@ Configure `AzureQueueMqSettings`, there are configuration methods which can be o
 
 ## Developing
 
-Requires NET core 2.x. and .NET Framework SDK 4.5.2, 4.7.2 and 4.8
+Requires NET core 2.x. and .NET Framework SDK 4.8
 
 Setting up test environment
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,14 +98,3 @@ jobs:
         dotnet pack $(Build.SourcesDirectory)\Protacon.RxMq.AzureServiceBus\Protacon.RxMq.AzureServiceBus.csproj -c Release -o $(Build.SourcesDirectory)\Protacon.RxMq.AzureServiceBus\artifacts /p:Version=$(buildTag) 
         cd  $(Build.SourcesDirectory)\Protacon.RxMq.AzureServiceBus\artifacts   
         dotnet nuget push Protacon.RxMq.AzureServiceBus.$(buildTag).nupkg --api-key $(nugetApiKey) --source https://api.nuget.org/v3/index.json  
-   
-  - task: PowerShell@2 
-    displayName: publish AzureServiceBusLegacy nuget packages
-    inputs:
-      targetType: 'inline'
-      script: |
-        dotnet pack $(Build.SourcesDirectory)\Protacon.RxMq.AzureServiceBusLegacy\Protacon.RxMq.AzureServiceBusLegacy.csproj -c Release -o $(Build.SourcesDirectory)\Protacon.RxMq.AzureServiceBusLegacy\artifacts /p:Version=$(buildTag) 
-        cd  $(Build.SourcesDirectory)\Protacon.RxMq.AzureServiceBusLegacy\artifacts   
-        dotnet nuget push Protacon.RxMq.AzureServiceBusLegacy.$(buildTag).nupkg --api-key $(nugetApiKey) --source https://api.nuget.org/v3/index.json
-
-    


### PR DESCRIPTION
Some build stuff from 4.0.0 were left behind. This removes them. Primarily the legacy nuget publish step.